### PR TITLE
chore: publish API docs to GitHub Pages via amp-catalog

### DIFF
--- a/.github/workflows/publish-api-docs.yml
+++ b/.github/workflows/publish-api-docs.yml
@@ -1,0 +1,20 @@
+name: Publish API docs
+
+# Publishes this API's Swagger UI to https://hmcts.github.io/<repo>/ on release.
+# All the work lives in the shared catalog workflow; this repo only declares
+# where its OpenAPI spec is. See https://github.com/hmcts/amp-catalog.
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  docs:
+    uses: hmcts/amp-catalog/.github/workflows/publish-swagger-ui.yml@v1
+    with:
+      openapi_path: src/main/resources/openapi/court-list-publisher.openapi.yml

--- a/src/main/resources/openapi/court-list-publisher.openapi.yml
+++ b/src/main/resources/openapi/court-list-publisher.openapi.yml
@@ -1,7 +1,11 @@
 openapi: 3.0.3
 servers:
-  - description: APIHub API Auto Mocking Scheduling and Listing court-schedule
-    url: https://virtserver.swaggerhub.com/HMCTS-DTS//api-cp-crime-court-list-publisher/0.0.0
+  - description: Common Platform API Crime Court List Publisher
+    url: https://api-cp-crime-court-list-publisher.net/{version}
+    variables:
+      version:
+        default: 0.0.0
+        description: API version; matches the spec info.version
 
 info:
   title: Common Platform API Crime Court List Publisher


### PR DESCRIPTION
Also replace the SwaggerHub virtserver `servers` entry with the standard
server URL pattern, since SwaggerHub virtservers are no longer available.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
